### PR TITLE
:ambulance: 修复数据类型为 formData 或 json 时，请求数据被解析

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,18 @@ const bodyParse = function(req, fn){
         arr.push(data);
     });
     req.on('end', function(){
-        let data = Buffer.concat(arr).toString(),ret;
-        try{
-            ret = qs.parse(data);
+        const bufferArr = Buffer.concat(arr);
+        let data = bufferArr.toString(),
+            ret;
+        const contentType = req['headers']['content-type'];
+        try {
+            if (contentType.indexOf('multipart/form-data') > -1) {
+                ret = bufferArr;
+            } else if (contentType.indexOf('application/json') > -1) {
+                ret = data;
+            } else {
+                ret = qs.parse(data);
+            }
         }catch(err){
             ret = {
                 code: 500,


### PR DESCRIPTION
## 问题描述：
qs.parse(data) 导致数据类型发生改变，和 content-type 不一致，导致请求参数无法被服务器正确读取。
## 变更：
当数据类型为 formData 或 json 时，去掉对请求数据的处理
